### PR TITLE
feat: add site-wide header nav with Home and Blog links

### DIFF
--- a/_includes/main.css
+++ b/_includes/main.css
@@ -5,6 +5,8 @@ body {
     line-height: 1.6;
     font-size: 1.08em;
     font-family: Helvetica, Arial, sans-serif;
+    background-color: #fff;
+    color: #111;
 }
 
 a {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,6 +29,14 @@
 </head>
 
 <body>
+  <header class="site-header">
+    <nav>
+      <ul>
+        <li><a href="/" {% if page.url == '/' %}class="active"{% endif %}>Home</a></li>
+        <li><a href="/blog/" {% if page.url contains '/blog' %}class="active"{% endif %}>Blog</a></li>
+      </ul>
+    </nav>
+  </header>
   <main>
     {{ content }}
   </main>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,7 +1,6 @@
 ---
 layout: default
 ---
-<a href="{{ '/blog/' | relative_url }}" aria-label="Blog">← Blog</a>
 <h1>{{ page.title }}</h1>
 <p class="meta">
   {{ page.date | date: "%B %e, %Y" }}

--- a/blog/index.md
+++ b/blog/index.md
@@ -4,8 +4,6 @@ title: Blog
 description: Articles and notes by Rezka Leonandya.
 permalink: /blog/
 ---
-<a href="{{ '/' | relative_url }}" aria-label="Home">← Home</a>
-
 # Blog
 
 <div class="tag-filters">


### PR DESCRIPTION
## Summary

- Add a persistent `<header>` with nav links (Home, Blog) to `_layouts/default.html` — visible on every page
- Active page is highlighted with an underline via Liquid conditionals (`page.url`)
- Explicitly set `background-color: #fff` and `color: #111` on `body` in `main.css` to prevent browser dark-mode override
- Remove now-redundant back links (`← Home` from blog index, `← Blog` from post layout)

## Test plan

- [x] Home page shows header with "Home" underlined
- [x] Blog index shows header with "Blog" underlined, no "← Home" back link
- [x] Individual post pages show header with "Blog" underlined, no "← Blog" back link
- [x] White background confirmed on both home and blog pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)